### PR TITLE
testAPI

### DIFF
--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -22,7 +22,7 @@ class TaskFactory extends Factory
     public function definition()
     {
         return [
-            //8〜30文字
+            //10〜30文字
             'title' => $this->faker->realText(rand(10,30)),
             //40％でtrue
             'is_done' => $this->faker->boolean(40),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,5 +27,7 @@
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
         <server name="TELESCOPE_ENABLED" value="false"/>
+        <!-- テスト用のデータベース -->
+        <env name="DB_DATABASE" value="test_database" />
     </php>
 </phpunit>

--- a/tests/Feature/ReportTest.php
+++ b/tests/Feature/ReportTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use App\Models\Task;
 
 class ReportTest extends TestCase
 {
@@ -26,5 +27,19 @@ class ReportTest extends TestCase
         ];
         $response = $this->post('api/tasks',$data);
         $response->assertStatus(201);
+    }
+    public function testPUT()
+    {
+        // App\Models\Taskインスタンスを一つ作成
+        $task = Task::factory()->create();
+        $task->title='テストデータ変更しました';
+        
+        //変更したいidを指定してください
+        $task->id=7;
+
+        //↓残ってるとデータが変更されなかった、テストを実行するときはコメントアウト
+        // dd($task);
+        $response = $this->patchJson("api/tasks/{$task->id}",$task->toArray());
+        $response->assertStatus(200);
     }
 }

--- a/tests/Feature/ReportTest.php
+++ b/tests/Feature/ReportTest.php
@@ -42,4 +42,17 @@ class ReportTest extends TestCase
         $response = $this->patchJson("api/tasks/{$task->id}",$task->toArray());
         $response->assertStatus(200);
     }
+    public function testDELETE()
+    {
+        // App\Models\Taskインスタンスを一つ作成
+        $task = Task::factory()->create();
+        
+        //変更したいidを指定してください
+        $task->id=8;
+
+        //↓残ってるとデータが変更されなかった、テストを実行するときはコメントアウト
+        dd($task);
+        $response = $this->deleteJson("api/tasks/{$task->id}");
+        $response->assertStatus(200);
+    }
 }

--- a/tests/Feature/ReportTest.php
+++ b/tests/Feature/ReportTest.php
@@ -51,7 +51,7 @@ class ReportTest extends TestCase
         $task->id=8;
 
         //↓残ってるとデータが変更されなかった、テストを実行するときはコメントアウト
-        dd($task);
+        // dd($task);
         $response = $this->deleteJson("api/tasks/{$task->id}");
         $response->assertStatus(200);
     }

--- a/tests/Feature/ReportTest.php
+++ b/tests/Feature/ReportTest.php
@@ -9,14 +9,15 @@ use Tests\TestCase;
 class ReportTest extends TestCase
 {
     /**
-     * A basic feature test example.
+     * api/tasks
+     * GETメソッド
      *
      * @return void
      */
-    public function test_example()
+    public function testGET()
     {
-        $response = $this->get('/');
-
+        $response = $this->get('api/tasks');
         $response->assertStatus(200);
     }
+
 }

--- a/tests/Feature/ReportTest.php
+++ b/tests/Feature/ReportTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ReportTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function test_example()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/ReportTest.php
+++ b/tests/Feature/ReportTest.php
@@ -19,5 +19,12 @@ class ReportTest extends TestCase
         $response = $this->get('api/tasks');
         $response->assertStatus(200);
     }
-
+    public function testPOST()
+    {
+        $data = [
+            'title' => 'テストデータ'
+        ];
+        $response = $this->post('api/tasks',$data);
+        $response->assertStatus(201);
+    }
 }


### PR DESCRIPTION
テスト用のデータベースtest_databaseは各自準備しておいて！
テストの実行
`vendor/bin/phpunit tests/Feature/ReportTest.php`
特定のテスト（メソッド）だけを実行する
`vendor/bin/phpunit tests/Feature/ReportTest.php --filter=メソッド名`
test_databaseのレコードが追加、更新、削除されるのが確認できます
(postでデータを渡さないとステータスコード500になる)
https://readouble.com/laravel/8.x/ja/database-testing.html

検証項目
- ~~api/tasksにGETメソッドでアクセスできる、ステータスコード200~~
- ~~api/tasksにPOSTメソッドで新規登録することができる、ステータスコード201~~
-  ~~api/tasks/{id}にPUTメソッドでリクエストしてレコードを更新することができる、ステータスコード200~~
- ~~api/tasks/{id}にDELETEメソッドでリクエストしてレコードを削除することができる、ステータスコード200~~